### PR TITLE
Fixing navigation 2

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -66,6 +66,12 @@
     color: var(--main-white);
 }
 
+@media (min-width: 575px){
+    #navContainer {
+        position: relative;
+    }
+}
+
 /* Styles for the active state */
 .navbar-button.active #line-1 {
     transform: rotate(45deg) translate(7.7px, 9px); /* Rotate the first line */
@@ -79,11 +85,6 @@
 .navbar-button.active #line-3 {
     transform: rotate(-45deg) translate(7.7px, -9px); /* Rotate the third line */
 }
-
-#navbarToggleExternalContent {
-   
-}
-
 
 /* Header */
 nav {

--- a/styles/style.css
+++ b/styles/style.css
@@ -81,46 +81,7 @@
 }
 
 #navbarToggleExternalContent {
-    position: absolute;
-    top: 100%;
-}
-
-@media (max-width: 575px) {
-    #navbarToggleExternalContent {
-        right: 0%; /* Moves inward slightly for extre-small screens */
-    }
-}
-
-@media (min-width: 576px) {
-    #navbarToggleExternalContent {
-        right: 0%; /* Moves inward slightly for small screens */
-    }
-}
-
-@media (min-width: 768px) {
-    #navbarToggleExternalContent {
-        right: 0%; /* Moves further inward for medium screens */
-    }
-}
-
-@media (min-width: 992px) {
-    #navbarToggleExternalContent {
-        left: 70%; /* Moves further inward for large screens */
-    }
-}
-
-@media (min-width: 1200px) {
-    #navbarToggleExternalContent {
-        left: 73%; /* Moves further inward for extra-large screens */
-        margin-right: 50px;
-    }
-}
-
-@media (min-width: 1400px) {
-    #navbarToggleExternalContent {
-        left: 78%; /* Moves further inward for extra-extra-large screens */
-        margin-right: 50px;
-    }
+   
 }
 
 

--- a/template/template.html
+++ b/template/template.html
@@ -20,7 +20,7 @@
                     <p class="my-auto">RBOCC</p>
                 </div>
 
-                <div class="d-flex align-items-center">
+                <div class="d-flex align-items-center position-relative">
                     <button href="" type="button" class="btn d-none d-lg-inline me-2 shadow">Portal</button>
                     <button href="" type="button" class="btn d-none d-lg-inline me-2 shadow">Contact</button>
                     <button class="navbar-button mx-2 bg-transparent shadow" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggleExternalContent" aria-controls="navbarToggleExternalContent" aria-expanded="false" aria-label="Toggle navigation" onclick="this.classList.toggle('active')">

--- a/template/template.html
+++ b/template/template.html
@@ -11,7 +11,7 @@
 <body>
     <header>
         <nav id="navbar" class="navbar">
-            <div class="container justify-content-between align-items-center">
+            <div id="navContainer" class="container justify-content-between align-items-center">
                 <a href="#" class="navbar-brand text-light align-items-center">
                     <img class="shadow" src="../../images/logo-color.png" alt="Logo" width="50px" height="auto">
                 </a>
@@ -20,7 +20,7 @@
                     <p class="my-auto">RBOCC</p>
                 </div>
 
-                <div class="d-flex align-items-center position-relative">
+                <div class="d-flex align-items-center">
                     <button href="" type="button" class="btn d-none d-lg-inline me-2 shadow">Portal</button>
                     <button href="" type="button" class="btn d-none d-lg-inline me-2 shadow">Contact</button>
                     <button class="navbar-button mx-2 bg-transparent shadow" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggleExternalContent" aria-controls="navbarToggleExternalContent" aria-expanded="false" aria-label="Toggle navigation" onclick="this.classList.toggle('active')">


### PR DESCRIPTION
I fixed the navigation so that it is always aligned perfectly with the main container width on screens above sm, and on any screen size below sm it will snap to the edge of the screen as it looks worse when the navigation is around 5px off from the edge as the screen size is already small. I also reduced the size of the css file significantly while doing so.